### PR TITLE
Bugfix/41 conan x cmake build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,7 @@ jobs:
       - name: build rtype
         run: |
           sudo pip install conan
-          cd OtterLib
-          sudo conan install . --build=missing -c tools.system.package_manager:mode=install
-          sudo rm conan.lock conanbuildinfo.cmake conanbuildinfo.txt conaninfo.txt graph_info.json
-          conan install . --build=missing
+          conan profile new --detect default
           cmake -S . -B build
           cd build
           cmake --build .
@@ -40,9 +37,6 @@ jobs:
         shell: pwsh
         run: |
           pip install conan
-          cd OtterLib
-          conan install . --build=missing -c tools.system.package_manager:mode=install
-          Remove-Item conan.lock, conanbuildinfo.cmake, conanbuildinfo.txt, conaninfo.txt, graph_info.json
           cmake -S . -B build -G "Visual Studio 17 2022"
           cd build/
           cmake --build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: build rtype
+      - name: Build RType on Linux
         run: |
           sudo pip install conan
           conan profile new --detect default
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - name: "TODO: build RType on Windows"
+      - name: Build RType on Windows
         shell: pwsh
         run: |
           pip install conan

--- a/OtterLib/CMakeLists.txt
+++ b/OtterLib/CMakeLists.txt
@@ -15,9 +15,10 @@ else()
     )
 endif()
 
+# Find Conan
 find_program(CONAN conan)
 if (NOT CONAN)
-    message(FATAL_ERROR "Conan not found!")
+    message(FATAL_ERROR "[Conan] Conan not found!")
 endif()
 
 # Check if conan is installed
@@ -25,17 +26,19 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
     include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
     conan_basic_setup()
 else()
-    # If not, install conan
+    # If not, install conan dependencies
+    message(STATUS "[Conan] Conan dependencies not installed, installing dependencies...")
     execute_process(
-            COMMAND conan install ${CMAKE_CURRENT_SOURCE_DIR} --build=missing
-            RESULT_VARIABLE result
+            COMMAND bash -c "conan install ${CMAKE_CURRENT_SOURCE_DIR} --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=true"
+            OUTPUT_VARIABLE result
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
+        message(STATUS "[Conan] Conan dependencies installed!")
         include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
         conan_basic_setup()
     else()
-        message(FATAL_ERROR "The file conanbuildinfo.cmake doesn't exist, you have to run conan install first")
+        message(FATAL_ERROR "[Conan] Conan install error: ${result}")
     endif()
 endif()
 

--- a/OtterLib/CMakeLists.txt
+++ b/OtterLib/CMakeLists.txt
@@ -15,6 +15,12 @@ else()
     )
 endif()
 
+if (WIN32)
+    set(CMAKE_SHELL "powershell.exe")
+else()
+    set(CMAKE_SHELL bash -c)
+endif()
+
 # Find Conan
 find_program(CONAN conan)
 if (NOT CONAN)
@@ -29,7 +35,7 @@ else()
     # If not, install conan dependencies
     message(STATUS "[Conan] Conan dependencies not installed, installing dependencies...")
     execute_process(
-            COMMAND bash -c "conan install ${CMAKE_CURRENT_SOURCE_DIR} --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=true"
+            COMMAND ${CMAKE_SHELL} "conan install ${CMAKE_CURRENT_SOURCE_DIR} --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=true"
             OUTPUT_VARIABLE result
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )

--- a/OtterLib/conanfile.txt
+++ b/OtterLib/conanfile.txt
@@ -1,9 +1,8 @@
 [requires]
-zlib/1.2.13
 sfml/2.5.1
 raylib/4.0.0
-boost/1.76.0
-asio/1.18.2
+boost/1.81.0
+asio/1.24.0
 
 [generators]
 cmake

--- a/OtterLib/graphic/include/OtterGraphic.hpp
+++ b/OtterLib/graphic/include/OtterGraphic.hpp
@@ -1,4 +1,6 @@
 
 namespace Otter::Graphic {
     void print_hello(void);
-}
+    void start(void);
+    void end(void);
+} // namespace Otter::Graphic

--- a/OtterLib/graphic/src/test.cpp
+++ b/OtterLib/graphic/src/test.cpp
@@ -1,7 +1,8 @@
-
-
 #include <iostream>
+#include <raylib.h>
 
 namespace Otter::Graphic {
     void print_hello() { std::cout << "Hello" << std::endl; }
+    void start() { InitWindow(800, 450, "raylib [core] example - basic window"); }
+    void end() { CloseWindow(); }
 } // namespace Otter::Graphic

--- a/games/rtype/CMakeLists.txt
+++ b/games/rtype/CMakeLists.txt
@@ -15,25 +15,6 @@ else()
     )
 endif()
 
-# Check if conan is installed
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
-    include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
-    conan_basic_setup()
-else()
-    # If not, install conan
-    execute_process(
-            COMMAND conan install ${CMAKE_CURRENT_SOURCE_DIR} --build=missing
-            RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
-        include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
-        conan_basic_setup()
-    else()
-        message(FATAL_ERROR "The file conanbuildinfo.cmake doesn't exist, you have to run conan install first")
-    endif()
-endif()
-
 # Build OtterLib
 set(OTTERLIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../OtterLib)
 file(MAKE_DIRECTORY ${OTTERLIB_DIR}/build)
@@ -53,8 +34,15 @@ execute_process(
     WORKING_DIRECTORY ${OTTERLIB_DIR}/build
 )
 
-
 add_subdirectory(${OTTERLIB_DIR} ${OTTERLIB_DIR}/build)
+
+# Check if conan dependencies are installed
+if(EXISTS ${OTTERLIB_DIR}/conanbuildinfo.cmake)
+    include(${OTTERLIB_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+else()
+    message(FATAL_ERROR "Conan dependencies not installed, please run 'conan install' in OtterLib directory")
+endif()
 
 file(GLOB CLIENT_FILES src/*.cpp)
 file(GLOB SERVER_FILES src/*.cpp)
@@ -65,6 +53,7 @@ target_compile_definitions(r-type_client PUBLIC TARGET_CLIENT)
 target_link_libraries(r-type_client
     OtterCore
     OtterNetwork
+    OtterGraphic
     ${CONAN_LIBS}
 )
 

--- a/games/rtype/conanfile.txt
+++ b/games/rtype/conanfile.txt
@@ -1,9 +1,0 @@
-[requires]
-zlib/1.2.13
-sfml/2.5.1
-raylib/4.0.0
-boost/1.76.0
-asio/1.18.2
-
-[generators]
-cmake

--- a/games/rtype/src/main.cpp
+++ b/games/rtype/src/main.cpp
@@ -1,7 +1,8 @@
+#include "OtterGraphic.hpp"
 #include "OtterNetwork.hpp"
 
 #include <iostream>
-#include <raylib.h>
+#include <unistd.h>
 
 int main(int ac, char** av)
 {
@@ -10,40 +11,9 @@ int main(int ac, char** av)
 #elif TARGET_SERVER
     std::cout << "SERVER" << std::endl;
 #endif
-    const int screenWidth = 800;
-    const int screenHeight = 450;
-
-    InitWindow(screenWidth, screenHeight, "raylib [core] example - basic window");
-
-    SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
-    //--------------------------------------------------------------------------------------
-
-    // Main game loop
-    while (!WindowShouldClose())    // Detect window close button or ESC key
-    {
-        // Update
-        //----------------------------------------------------------------------------------
-        // TODO: Update your variables here
-        //----------------------------------------------------------------------------------
-
-        // Draw
-        //----------------------------------------------------------------------------------
-        BeginDrawing();
-
-        ClearBackground(RAYWHITE);
-
-        DrawText("Congrats! You created your first window!", 190, 200, 20, LIGHTGRAY);
-
-        EndDrawing();
-        //----------------------------------------------------------------------------------
-    }
-
-    // De-Initialization
-    //--------------------------------------------------------------------------------------
-    CloseWindow();        // Close window and OpenGL context
-    //--------------------------------------------------------------------------------------
-
-    return 0;
     Otter::Network::print_hello();
+    Otter::Graphic::start();
+    sleep(10);
+    Otter::Graphic::end();
     return 0;
 }

--- a/games/rtype/src/main.cpp
+++ b/games/rtype/src/main.cpp
@@ -2,7 +2,6 @@
 #include "OtterNetwork.hpp"
 
 #include <iostream>
-#include <unistd.h>
 
 int main(int ac, char** av)
 {
@@ -13,7 +12,6 @@ int main(int ac, char** av)
 #endif
     Otter::Network::print_hello();
     Otter::Graphic::start();
-    sleep(10);
     Otter::Graphic::end();
     return 0;
 }


### PR DESCRIPTION
Fix conan x cmake build:

- Simplify the process of libs building (now only in Otterlib)
- Clean the steps of the github action
- Update dependencies (remove useless & update version for boost & asio)
- Fix automatic `conan install` into cmake

Close #41