### PR TITLE
Feature/57 add ci for tests launch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           conan profile new --detect default
           cmake -S . -B build
           cd build
-          cmake --build .
+          cmake --build . --target r-type
   build_windows:
     name: On Windows
     runs-on: windows-latest
@@ -39,4 +39,4 @@ jobs:
           pip install conan
           cmake -S . -B build -G "Visual Studio 17 2022"
           cd build/
-          cmake --build .
+          cmake --build . --target r-type

--- a/OtterLib/CMakeLists.txt
+++ b/OtterLib/CMakeLists.txt
@@ -107,17 +107,26 @@ target_include_directories(OtterGraphicTests PUBLIC graphic/include)
 target_link_libraries(OtterGraphicTests gtest_main ${CONAN_LIBS})
 add_test(NAME OtterGraphicTests COMMAND OtterGraphicTests)
 
+# Does not compile tests
+add_custom_target(OtterLib)
+add_dependencies(OtterLib OtterCore OtterNetwork OtterGraphic)
+
+# Compile tests only
+add_custom_target(OtterLibTests)
+add_dependencies(OtterLibTests OtterCoreTests OtterNetworkTests OtterGraphicTests)
+
 # Find headers
 file(GLOB CORE_HEADERS core/include/*.hpp)
 file(GLOB NETWORK_HEADERS network/include/*.hpp)
 file(GLOB GRAPHIC_HEADERS graphic/include/*.hpp)
 
 # Add headers to installed elements
-install(FILES 
+install(FILES
     ${GRAPHIC_HEADERS}
     ${NETWORK_HEADERS}
     ${CORE_HEADERS}
-    DESTINATION "include")
+    DESTINATION "include"
+)
 
 # Add static libraries to installed elements
 # Export them for use in other CMakes

--- a/README.md
+++ b/README.md
@@ -5,6 +5,35 @@ OtterLib is our game engine library developped for an Epitech project called R-T
 It consists of different modules: "Otter Core", "Otter Network" [...]
 
 
+## Building Rtype Games
+
+```bash
+cmake -S . -B build
+cmake --build build --target r-type
+```
+
+The built files are located in  `build/games/rtype/bin`
+
+## Building OtterLib
+
+```bash
+cmake -S . -B build
+cmake --build build --target OtterLib
+```
+
+The built files are located in  `OtterLib/build/lib`
+
+## Building and running tests
+
+### OtterLibTests
+
+```bash
+cmake -S . -B build
+cmake --build build --target OtterLibTests
+```
+
+The built files are located in  `OtterLib/build/lib`
+
 ## Contributing
 
 Contributions are always welcome!

--- a/games/rtype/CMakeLists.txt
+++ b/games/rtype/CMakeLists.txt
@@ -29,7 +29,7 @@ if(result)
 endif()
 
 execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
+    COMMAND ${CMAKE_COMMAND} --build . --target OtterLib
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${OTTERLIB_DIR}/build
 )
@@ -70,6 +70,11 @@ target_link_libraries(r-type_server
     OtterGraphic
     ${CONAN_LIBS}
 )
+
+# Does not compile tests
+add_custom_target(r-type)
+add_dependencies(r-type r-type_server r-type_client)
+
 
 install(
     TARGETS r-type_server r-type_client


### PR DESCRIPTION
No ci yet, but tests targets and release targets have been better defined, and the README.md contains building directives.
Pushing so devs can access these improvments